### PR TITLE
slow back bullets when walking

### DIFF
--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -253,6 +253,7 @@ function controlPlayer(body, floor) {
 
     window.addEventListener('keyup', function(ev) {
         if (ev.which === 39) {
+            gloabalBulletSpeed = NORMAL_BULLET_SPEED
             globalSpeedX = WALKING_SPEED;
         }
         if (ev.which === 37) {


### PR DESCRIPTION
when player runs bullets fly faster to him, but they need to slow down when player slows speed